### PR TITLE
Fixes download of hdf5 files

### DIFF
--- a/osparc/api_client.py
+++ b/osparc/api_client.py
@@ -556,8 +556,12 @@ class ApiClient(object):
                                  content_disposition).group(1)
             path = os.path.join(os.path.dirname(path), filename)
 
-        with open(path, "w") as f:
-            f.write(response.data)
+        try:
+            with open(path, "w") as f:
+                f.write(response.data)
+        except TypeError:
+            with open(path, "wb") as f:
+                f.write(response.data)
 
         return path
 

--- a/osparc/rest.py
+++ b/osparc/rest.py
@@ -220,10 +220,11 @@ class RESTClientObject(object):
             # In the python 3, the response.data is bytes.
             # we need to decode it to string.
             if six.PY3:
-                r.data = r.data.decode('utf8')
-
-            # log response body
-            logger.debug("response body: %s", r.data)
+                try:
+                    r.data = r.data.decode('utf8')
+                except UnicodeDecodeError:
+                    # NOTE: hdf5 files cannot be decoded
+                    pass
 
         if not 200 <= r.status <= 299:
             raise ApiException(http_resp=r)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 NAME = "osparc"
 VERSION = "0.4.3"
 API_VERSION = "0.4"
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil"]
+REQUIRES = ["urllib3 >= 1.26.4", "six >= 1.10", "certifi", "python-dateutil"]
 README = Path("README.md").read_text()
 
 setup(


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
Save binary responses to file 

## Related issue/s

-  Downloading hdf5 files raises exception: #23  


## How to test

```command
pip install git+https://github.com/ITISFoundation/osparc-simcore-python-client.git@is23/fix-binary-responses
```
- upload/download an hdf5 file
- check is the right file

